### PR TITLE
fix: checking if dataPath exists on error details

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ const jsonschemaErrors = handler => {
       detail: error.message,
       source: {
         pointer: error.schemaPath.substr(1),
-        parameter: error.dataPath.substr(1)
+        parameter: error.dataPath == undefined ? error.instancePath.substr(1) : error.dataPath.substr(1)
       },
       meta: error.params
     }))

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ const jsonschemaErrors = handler => {
       detail: error.message,
       source: {
         pointer: error.schemaPath.substr(1),
-        parameter: error.dataPath == undefined ? error.instancePath.substr(1) : error.dataPath.substr(1)
+        parameter:  (error.dataPath || error.instancePath).substr(1)
       },
       meta: error.params
     }))


### PR DESCRIPTION
New version of ajv don't use dataPath on error details they changed to instancePath(https://ajv.js.org/v6-to-v8-migration.html)
- Added validation to cover both cases to make ir work for previous versions of ajv inside middy-validator.